### PR TITLE
build: pin GitHub Actions using hashes

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -12,20 +12,20 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
   lint:
@@ -34,24 +34,22 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm package manager
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run the lint script in package.json scripts
-        run: |
-          pnpm run --if-present lint
+        run: pnpm run --if-present lint
 
   build:
     runs-on: ubuntu-latest
@@ -59,41 +57,37 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm package manager
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run the build script in package.json scripts
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: Run the lint-build script in package.json scripts
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present lint-build
+        run: pnpm run --if-present lint-build
 
       - name: Run the test-build script in package.json scripts
         env:
           BASE_URL: "/utrecht/"
-        run: |
-          pnpm run --if-present test-build
+        run: pnpm run --if-present test-build
 
       - name: Upload the Storybook artifact from the build step
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: storybook
           path: packages/storybook/dist/
@@ -105,24 +99,22 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
-        run: |
-          pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run the test script in package.json scripts
-        run: |
-          pnpm run --if-present test
+        run: pnpm run --if-present test
 
   publish-website:
     runs-on: ubuntu-latest
@@ -131,16 +123,16 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Download the Storybook artifact from the "Build" job
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: storybook
           path: packages/storybook/dist/
 
       - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@5c6e9e9f3672ce8fd37b9856193d2a537941e66c # v4.6.1
         with:
           branch: gh-pages
           folder: packages/storybook/dist/
@@ -154,27 +146,26 @@ jobs:
 
     steps:
       - name: Download code from GitHub
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           token: ${{ secrets.GH_TOKEN }}
 
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm package manager
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies specified in package.json
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
       - name: Run the build script from package.json scripts
-        run: |
-          pnpm run --if-present build
+        run: pnpm run --if-present build
 
       - name: Publish to GitHub repository
         env:


### PR DESCRIPTION
Pin GitHub Actions using hashes to prevent tampering. Tags are added as comments and both hashes and tags will be updated by Dependabot in pull requests.

Update all actions to their latest versions.

Make it explicit that `pnpm install` is run with `--frozen-lockfile` in CI.